### PR TITLE
Fix compile errors on MSVC

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 import io
 import os
+import platform
+
 try:
     from setuptools import setup, Extension
 except ImportError:
@@ -10,64 +12,115 @@ try:
     from Cython.Build import cythonize
     import numpy
 except:
-    raise SystemExit("Cython>=0.28 and numpy are required. Please install before proceeding")
+    raise SystemExit(
+        "Cython>=0.28 and numpy are required. Please install before proceeding"
+    )
 
 REQUIRED = ["numpy>=1.14", "Cython>=0.28", "scipy>=1.1", "numdifftools>=0.9"]
 EXTRA_REQUIRED = {"test": ["mock", "nose"], "docs": ["Sphinx", "sphinx-rtd-theme>=0.4"]}
 DESCRIPTION = "parameter estimation for simple Hawkes (self-exciting) processes"
 CLASSIFIERS = [
-    'Programming Language :: Python',
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Cython',
-    'Development Status :: 3 - Alpha',
-    'Intended Audience :: Developers',
-    'Intended Audience :: Science/Research',
-    'License :: OSI Approved :: MIT License',
-    'Topic :: Scientific/Engineering',
-    'Topic :: Scientific/Engineering :: Information Analysis'
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 2",
+    "Programming Language :: Cython",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Information Analysis",
 ]
 
 # make description
 try:
     here = os.path.abspath(os.path.dirname(__file__))
-    with io.open(os.path.join(here, 'README.markdown'), encoding='utf-8') as f:
-        LONG_DESCRIPTION = '\n' + f.read()
+    with io.open(os.path.join(here, "README.markdown"), encoding="utf-8") as f:
+        LONG_DESCRIPTION = "\n" + f.read()
 except:
     LONG_DESCRIPTION = DESCRIPTION
 
 # cythonize extensions
-ext_mods = cythonize(
-    [Extension("hawkeslib.model.c.c_uv_exp", ["hawkeslib/model/c/c_uv_exp.pyx"], include_dirs=[numpy.get_include()],
-               libraries=["m"],
-               language="c++",
-               extra_compile_args=["-O3", "-march=native"]),
-    Extension("hawkeslib.model.c.c_mv_exp", ["hawkeslib/model/c/c_mv_exp.pyx"], include_dirs=[numpy.get_include()],
-               libraries=["m"],
-               language="c++",
-               extra_compile_args=["-O3", "-march=native"]),
-    Extension("hawkeslib.model.c.c_uv_bayes", ["hawkeslib/model/c/c_uv_bayes.pyx"], include_dirs=[numpy.get_include()],
-               libraries=["m"],
-               extra_compile_args=["-O3", "-march=native"]),
-    Extension("hawkeslib.model.c.c_mv_samp", ["hawkeslib/model/c/c_mv_samp.pyx"], include_dirs=[numpy.get_include()],
-               libraries=["m"],
-               language="c++",
-               extra_compile_args=["-O3", "-march=native"])
-    ])
+ext_mods = None
+if platform.system() == "Windows":
+    ext_mods = cythonize(
+        [
+            Extension(
+                "hawkeslib.model.c.c_uv_exp",
+                ["hawkeslib/model/c/c_uv_exp.pyx"],
+                include_dirs=[numpy.get_include()],
+                language="c++",
+            ),
+            Extension(
+                "hawkeslib.model.c.c_mv_exp",
+                ["hawkeslib/model/c/c_mv_exp.pyx"],
+                include_dirs=[numpy.get_include()],
+                language="c++",
+            ),
+            Extension(
+                "hawkeslib.model.c.c_uv_bayes",
+                ["hawkeslib/model/c/c_uv_bayes.pyx"],
+                include_dirs=[numpy.get_include()],
+            ),
+            Extension(
+                "hawkeslib.model.c.c_mv_samp",
+                ["hawkeslib/model/c/c_mv_samp.pyx"],
+                include_dirs=[numpy.get_include()],
+                language="c++",
+            ),
+        ]
+    )
+else:
+    ext_mods = cythonize(
+        [
+            Extension(
+                "hawkeslib.model.c.c_uv_exp",
+                ["hawkeslib/model/c/c_uv_exp.pyx"],
+                include_dirs=[numpy.get_include()],
+                libraries=["m"],
+                language="c++",
+                extra_compile_args=["-O3", "-march=native"],
+            ),
+            Extension(
+                "hawkeslib.model.c.c_mv_exp",
+                ["hawkeslib/model/c/c_mv_exp.pyx"],
+                include_dirs=[numpy.get_include()],
+                libraries=["m"],
+                language="c++",
+                extra_compile_args=["-O3", "-march=native"],
+            ),
+            Extension(
+                "hawkeslib.model.c.c_uv_bayes",
+                ["hawkeslib/model/c/c_uv_bayes.pyx"],
+                include_dirs=[numpy.get_include()],
+                libraries=["m"],
+                extra_compile_args=["-O3", "-march=native"],
+            ),
+            Extension(
+                "hawkeslib.model.c.c_mv_samp",
+                ["hawkeslib/model/c/c_mv_samp.pyx"],
+                include_dirs=[numpy.get_include()],
+                libraries=["m"],
+                language="c++",
+                extra_compile_args=["-O3", "-march=native"],
+            ),
+        ]
+    )
 
-setup(name="hawkeslib",
-      version="0.2.2",
-      description=DESCRIPTION,
-      long_description=LONG_DESCRIPTION,
-      long_description_content_type="text/markdown",
-      author="Caner Turkmen",
-      author_email="caner.turkmen@boun.edu.tr",
-      url="http://hawkeslib.rtfd.io",
-      ext_modules=ext_mods,
-      packages=["hawkeslib", "hawkeslib.model", "hawkeslib.model.c", "hawkeslib.util"],
-      install_requires=REQUIRED,
-      extras_require=EXTRA_REQUIRED,
-      setup_requires=["numpy", "cython", "scipy"],
-      license="MIT",
-      python_requires=">=2.7.5",
-      classifiers=CLASSIFIERS
+setup(
+    name="hawkeslib",
+    version="0.2.2",
+    description=DESCRIPTION,
+    long_description=LONG_DESCRIPTION,
+    long_description_content_type="text/markdown",
+    author="Caner Turkmen",
+    author_email="caner.turkmen@boun.edu.tr",
+    url="http://hawkeslib.rtfd.io",
+    ext_modules=ext_mods,
+    packages=["hawkeslib", "hawkeslib.model", "hawkeslib.model.c", "hawkeslib.util"],
+    install_requires=REQUIRED,
+    extras_require=EXTRA_REQUIRED,
+    setup_requires=["numpy", "cython", "scipy"],
+    license="MIT",
+    python_requires=">=2.7.5",
+    classifiers=CLASSIFIERS,
 )


### PR DESCRIPTION
Fix the following error on Windows platform:
```
temp.win-amd64-3.6\Release\hawkeslib/model/c\c_mv_exp.cp36-win_amd64.exp
    Generating code
    Finished generating code
    building 'hawkeslib.model.c.c_uv_bayes' extension
    C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.25.28610\bin\HostX86\x64\cl.exe /c /nologo /Ox /W3 /GL /DNDEBUG /MD -Ic:\users\clan\appdata\local\programs\python\python36\lib\site-packages\numpy\core\include -Ic:\users\clan\appdata\local\programs\python\python36\include -Ic:\users\clan\appdata\local\programs\python\python36\include "-IC:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.25.28610\ATLMFC\include" "-IC:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.25.28610\include" "-IC:\Program Files (x86)\Windows Kits\NETFXSDK\4.6.2\include\um" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\ucrt" "-IC:\Pro62.0\um" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\winrt" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.18362.0\cppwinrt" /Tchawkeslib/model/c/c_uv_bayes.c /Fobuild\temp.win-amd64-3.6\Release\hawkeslib/model/c/c_uv_bayes.obj -O3 -march=native
    cl : Command line warning D9002 : ignoring unknown option '-O3'
    cl : Command line warning D9002 : ignoring unknown option '-march=native'
    c_uv_bayes.c
    C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.25.28610\bin\HostX86\x64\link.exe /nologo /INCREMENTAL:NO /LTCG /DLL /MANIFEST:EMBED,ID=2 /MANIFESTUAC:NO /LIBPATH:c:\users\clan\appdata\local\programs\python\python36\libs /LIBPATH:c:\users\clan\appdata\local\programs\python\python36\PCbuild\amd64 "/LIBPATH:C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.25.28610\ATLMFC\lib\x64" "/LIBPATH:C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.25.28610\lib\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\NETFXSDK\4.6.2\lib\um\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\10\lib\10.0.18362.0\ucrt\x64" "/LIBPATH:C:\Program Files (x86)\Windows Kits\10\lib\10.0.18362.0\um\x64" m.lib /EXPORT:PyInit_c_uv_bayes build\temp.win-amd64-3.6\Release\hawkeslib/model/c/c_uv_bayes.obj /OUT:build\lib.win-amd64-3.6\hawkeslib\model\c\c_uv_bayes.cp36-win_amd64.pyd /IMPLIB:build\temp.win-amd64-3.6\Release\hawkeslib/model/c\c_uv_bayes.cp36-win_amd64.lib
    LINK : fatal error LNK1181: cannot open input file 'm.lib'
    error: command 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\14.25.28610\\bin\\HostX86\\x64\\link.exe' failed with exit status 1181
```